### PR TITLE
Support multi-byte character in QR code

### DIFF
--- a/lib/barby/barcode/qr_code.rb
+++ b/lib/barby/barcode/qr_code.rb
@@ -71,7 +71,7 @@ module Barby
       return @size if @size
 
       level_index = LEVELS[level]
-      length = data.length
+      length = data.bytesize
       found_size = nil
       SIZES.each do |size,max_values|
         if max_values[level_index] >= length


### PR DESCRIPTION
Support multi-byte character (Japanese and Chinese for example) in QR code generation

For barby issue 'Exception in generating QR code with Japanese and Chinese character'
